### PR TITLE
Support other engines

### DIFF
--- a/src/resource/cluster.ts
+++ b/src/resource/cluster.ts
@@ -16,7 +16,7 @@ export class Cluster extends Resource<IPluginOptions> {
             [this.getName(NamePostFix.DATABASE_CLUSTER)]: {
                 "Type": "AWS::RDS::DBCluster",
                 "Properties": {
-                    "Engine": "aurora",
+                    "Engine": this.options.engine || "aurora",
                     "EngineMode": "serverless",
                     "DBClusterIdentifier": this.options.identifier || "AuroraClusterID" + this.stage,
                     "MasterUsername": this.options.username,


### PR DESCRIPTION
As of today, Aurora serverless supports 3 engines, "aurora" "aurora-mysql" "aurora-postgresql"